### PR TITLE
Fix flake check workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,15 @@ jobs:
       - name: Prepare hardware configuration
         run: |
           sudo mkdir -p /etc/nixos
-          echo '{ config, lib, pkgs, modulesPath, ... }: {}' | sudo tee /etc/nixos/hardware-configuration.nix
+          cat <<'EOF' | sudo tee /etc/nixos/hardware-configuration.nix
+{ config, lib, pkgs, modulesPath, ... }:
+{
+  fileSystems."/" = {
+    device = "none";
+    fsType = "tmpfs";
+  };
+}
+EOF
       - name: Run flake check
         run: |
           nix flake check --impure


### PR DESCRIPTION
## Summary
- update CI workflow so the flake can be evaluated
  - create a dummy `/etc/nixos/hardware-configuration.nix`
  - run `nix flake check --impure`

## Testing
- `nix flake check --impure` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c5b5477c8329bbd810dbf46cdca7