### PR TITLE
Fix CI branch filters

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,8 +2,15 @@ name: Nix Flake Check
 
 on:
   push:
-    branches: [ "master" ]
+    branches:
+      - master
+      - work
+      - main
   pull_request:
+    branches:
+      - master
+      - work
+      - main
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- allow GitHub Actions to run on the `master`, `work`, and `main` branches

## Testing
- `nix flake check --impure` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684419fed2c08329b5e531979d865f07